### PR TITLE
~quarter memory usage on file writing

### DIFF
--- a/signal-message-exporter.py
+++ b/signal-message-exporter.py
@@ -307,7 +307,7 @@ logging.info(f'Finished media export. Messages exported: {mms_counter} Errors: {
 smses.setAttribute("count", str(sms_counter + mms_counter))
 
 with open("sms-backup-restore.xml", "w") as f:
-    root.writexml(f)
+    root.writexml(f, encoding="utf-8", standalone="yes")
 
 conn.commit()
 cursor.close()

--- a/signal-message-exporter.py
+++ b/signal-message-exporter.py
@@ -306,9 +306,8 @@ logging.info(f'Finished media export. Messages exported: {mms_counter} Errors: {
 # update the total count
 smses.setAttribute("count", str(sms_counter + mms_counter))
 
-# xml_str = root.toprettyxml(indent="\t")
 with open("sms-backup-restore.xml", "w") as f:
-    f.write(root.toxml(encoding="utf-8", standalone="yes").decode())
+    root.writexml(f)
 
 conn.commit()
 cursor.close()


### PR DESCRIPTION
I've got a ~16GB Signal backup that I'm attempting to convert and was unable to run this script without a MemoryError upon trying to write the file (on a 64GB machine). Switching to the minidom `writexml` method reduced that to ~30GB of memory usage.

Opening this as a draft because I've yet to actually attempt ingesting the file on my phone