### PR TITLE
Update signal-message-exporter.py

### DIFF
--- a/signal-message-exporter.py
+++ b/signal-message-exporter.py
@@ -168,7 +168,7 @@ def xml_create_mms(root, row, parts, addrs):
         t = TYPES[int(row.get('type', 20))]
     except KeyError:
         t = 1
-    mms.setAttribute('type', str(t))
+    mms.setAttribute('msg_box', str(t))
     mms.setAttribute('rr', 'null')
     mms.setAttribute('sub', 'null')
     mms.setAttribute('read_status', '1')


### PR DESCRIPTION
This is needed to fix a major bug. I got a little carried away with find and replace when updating from Signal's old database format, which had changed the name of the 'msg_box' column to 'type'. The XML still needs to have the msg_box attribute or MMS messages sent from the user's phone will not reflect the correct sender.