### PR TITLE
Fix for m_type == null

### DIFF
--- a/signal-message-exporter.py
+++ b/signal-message-exporter.py
@@ -430,7 +430,7 @@ for row in cursor.fetchall():
             mms_counter -= 1
             raise
 
-    elif row["type"] in export_types and row["m_type"] == 0 and row["story_type"] == 0:
+    elif row["type"] in export_types and (row["m_type"] == 0 or row["m_type"] == 'null') and row["story_type"] == 0:
         # No body in SMS means no message. Let's avoid creating empty messages.
         # Some system-generated messages in Signal (such as alerts that a user's
         # number has changed) have a null body.


### PR DESCRIPTION
While migrating from Signal to Google Messages I found that a lot of recent messages received were not included in the generated `sms-backup-restore.xml` file. However running `signalbackup-tools --exporthtml` manually I saw that the messages were definitely in the backup file.

So after some digging around in a CSV dump I see that some SMS messages have `m_type = null` (or rather, blank, in the CSV) and others have `m_type = 0`. But the python script only handles `m_type = 0` at the moment.

This patch fixes this issue for me. I cannot say if I got all of them, but my status went from

`Messages exported: 3045 Errors: 0 Skipped internal Signal messages: 119`

to

`Messages exported: 3127 Errors: 0 Skipped internal Signal messages: 37`

So it should at least be an improvement.

I'm going to dig in and check the contents of the last 37 messages later, but for now I figured I should send this pull request at least.